### PR TITLE
fix: add Edit menu so copy/paste works on macOS

### DIFF
--- a/apps/desktop/src/main/menu.ts
+++ b/apps/desktop/src/main/menu.ts
@@ -138,6 +138,7 @@ export function buildAppMenu(handlers: AppMenuHandlers): Menu {
         isMac ? { role: 'close' } : { role: 'quit' },
       ],
     },
+    { role: 'editMenu' as const },
     {
       label: L.view,
       submenu: [


### PR DESCRIPTION
Paste (Cmd+V) doesn't work anywhere in the app on macOS: URL field, settings inputs, all of them. Same for Cmd+C/X/A.

The reason is that macOS dispatches those shortcuts through the application menu rather than the focused element, and the menu in menu.ts doesn't define an Edit menu, so there's nothing carrying the copy/paste/cut roles for the OS to route to.

One-line fix: add `{ role: 'editMenu' }` to the template. That gives the standard Edit menu (undo/redo/cut/copy/paste/select all) with the right shortcuts on each platform.

Tested on macOS: paste works in the inputs now, and the Edit menu shows up between File and View. Nothing Windows/Linux specific changed.

If you'd rather the labels went through your menu-i18n (L.*) setup instead of the built-in role, I can swap it.
