### PR TITLE
docs: fix typo 'targetting' → 'targeting' in mcp-bridge comment

### DIFF
--- a/apps/desktop/src/main/mcp-bridge.ts
+++ b/apps/desktop/src/main/mcp-bridge.ts
@@ -96,7 +96,7 @@ export interface McpBridgeDeps {
   /** Absolute path to the active `.seoproject`, or null if none. */
   getProjectPath: () => string | null;
   /** Row count for the active project — useful for confirming the
-   * MCP-side read-only view is targetting the same DB. */
+   * MCP-side read-only view is targeting the same DB. */
   getUrlCount: () => number;
   /** Optional logger (info / warn / error). When omitted, the bridge
    *  swallows internal trace; only HTTP-visible errors propagate. */


### PR DESCRIPTION
## What

Fixes a small spelling typo in a code comment: `targetting` → `targeting`.

## Where

`apps/desktop/src/main/mcp-bridge.ts:99` — the `getUrlCount` doc comment in `McpBridgeDeps`.

```diff
-   * MCP-side read-only view is targetting the same DB. */
+   * MCP-side read-only view is targeting the same DB. */
```

`targetting` (double-t) is a misspelling in both US and UK English; the correct form is `targeting`.

## Scope

Comment-only change — no behavior, no API, no build impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)